### PR TITLE
Create Get Endpoint to get asset by AssetId, to be used by the Repairs API

### DIFF
--- a/AssetInformationApi.Tests/DynamoDbIntegrationTests.cs
+++ b/AssetInformationApi.Tests/DynamoDbIntegrationTests.cs
@@ -33,6 +33,16 @@ namespace AssetInformationApi.Tests
                         }),
                         Projection = new Projection { ProjectionType = ProjectionType.ALL },
                         ProvisionedThroughput = new ProvisionedThroughput(10 , 10)
+                    },
+                    new GlobalSecondaryIndex
+                    {
+                        IndexName = "AssetId",
+                        KeySchema = new List<KeySchemaElement>(new[]
+                        {
+                            new KeySchemaElement("assetId", KeyType.HASH)
+                        }),
+                        Projection = new Projection { ProjectionType = ProjectionType.ALL },
+                        ProvisionedThroughput = new ProvisionedThroughput(10 , 10)
                     }
                 })
             }

--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/GetAssetByAssetIsRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/GetAssetByAssetIsRequestValidatorTests.cs
@@ -1,0 +1,47 @@
+using AssetInformationApi.V1.Boundary.Request;
+using AssetInformationApi.V1.Boundary.Request.Validation;
+using FluentValidation.TestHelper;
+using System;
+using Xunit;
+
+namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
+{
+    public class GetAssetByAssetIsRequestValidatorTests
+    {
+        private readonly GetAssetByAssetIdRequestValidator _sut;
+
+        public GetAssetByAssetIsRequestValidatorTests()
+        {
+            _sut = new GetAssetByAssetIdRequestValidator();
+        }
+
+        [Fact]
+        public void WhenNullHasError()
+        {
+            // Arrange
+            var model = new GetAssetByAssetIdRequest();
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.AssetId);
+        }
+
+        [Fact]
+        public void WhenEmptyHasError()
+        {
+            // Arrange
+            var model = new GetAssetByAssetIdRequest
+            {
+                AssetId = ""
+            };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.AssetId);
+        }
+    }
+}

--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/GetAssetByAssetIsRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/GetAssetByAssetIsRequestValidatorTests.cs
@@ -1,6 +1,7 @@
 using AssetInformationApi.V1.Boundary.Request;
 using AssetInformationApi.V1.Boundary.Request.Validation;
 using FluentValidation.TestHelper;
+using Hackney.Shared.Tenure.Boundary.Requests.Validation;
 using System;
 using Xunit;
 
@@ -9,6 +10,7 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
     public class GetAssetByAssetIsRequestValidatorTests
     {
         private readonly GetAssetByAssetIdRequestValidator _sut;
+        private const string StringWithTags = "Some string with <tag> in it.";
 
         public GetAssetByAssetIsRequestValidatorTests()
         {
@@ -42,6 +44,23 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
 
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.AssetId);
+        }
+
+        [Fact]
+        public void ShouldErrorWhenContainsTags()
+        {
+            // Arrange
+            var model = new GetAssetByAssetIdRequest
+            {
+                AssetId = StringWithTags
+            };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.AssetId)
+                .WithErrorCode(ErrorCodes.XssCheckFailure);
         }
     }
 }

--- a/AssetInformationApi.Tests/V1/E2ETests/Fixtures/AssetsFixture.cs
+++ b/AssetInformationApi.Tests/V1/E2ETests/Fixtures/AssetsFixture.cs
@@ -12,6 +12,7 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Fixtures
 
         public AssetDb Asset { get; private set; }
         public Guid AssetId { get; private set; }
+        public string PropertyReference { get; set; }
         public string InvalidAssetId { get; private set; }
 
         public AssetsFixture(IDynamoDBContext dbContext)
@@ -44,6 +45,7 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Fixtures
                 .Create();
 
             AssetId = Asset.Id;
+            PropertyReference = Asset.AssetId;
 
             _dbContext.SaveAsync(Asset).GetAwaiter().GetResult();
         }
@@ -51,6 +53,7 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Fixtures
         public void GivenAnAssetThatDoesntExist()
         {
             AssetId = Guid.NewGuid();
+            PropertyReference = _fixture.Create<string>();
         }
 
         public void GivenAnInvalidAssetId()

--- a/AssetInformationApi.Tests/V1/E2ETests/Steps/GetAssetByAssetIdSteps.cs
+++ b/AssetInformationApi.Tests/V1/E2ETests/Steps/GetAssetByAssetIdSteps.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Hackney.Shared.Asset.Boundary.Response;
+using Hackney.Shared.Asset.Factories;
+using Hackney.Shared.Asset.Infrastructure;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace AssetInformationApi.Tests.V1.E2ETests.Steps
+{
+    public class GetAssetByAssetIdSteps : BaseSteps
+    {
+        public GetAssetByAssetIdSteps(HttpClient httpClient) : base(httpClient)
+        { }
+
+        public async Task WhenTheGetApiIsCalled(string id)
+        {
+            var route = $"api/v1/assets/assetId/{id}";
+            var uri = new Uri(route, UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+
+        private async Task<AssetResponseObject> ExtractResultFromHttpResponse(HttpResponseMessage response)
+        {
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var apiResult = JsonSerializer.Deserialize<AssetResponseObject>(responseContent, _jsonOptions);
+            return apiResult;
+        }
+
+        public async Task ThenTheAssetDetailsAreReturned(AssetDb expectedAssetDb)
+        {
+            var apiAsset = await ExtractResultFromHttpResponse(_lastResponse).ConfigureAwait(false);
+
+            var expected = expectedAssetDb.ToDomain().ToResponse();
+            apiAsset.Should().BeEquivalentTo(expected);
+        }
+
+        public void ThenBadRequestIsReturned()
+        {
+            _lastResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        public void ThenNotFoundIsReturned()
+        {
+            _lastResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+    }
+}

--- a/AssetInformationApi.Tests/V1/E2ETests/Stories/GetAssetByAssetIdTests.cs
+++ b/AssetInformationApi.Tests/V1/E2ETests/Stories/GetAssetByAssetIdTests.cs
@@ -1,0 +1,67 @@
+using AssetInformationApi.Tests.V1.E2ETests.Fixtures;
+using AssetInformationApi.Tests.V1.E2ETests.Steps;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace AssetInformationApi.Tests.V1.E2ETests.Stories
+{
+    [Story(
+        AsA = "Service",
+        IWant = "an endpoint to return asset details",
+        SoThat = "it is possible to view the details of an asset.")]
+    [Collection("DynamoDb collection")]
+    public class GetAssetByAssetIdTests : IDisposable
+    {
+        private readonly DynamoDbIntegrationTests<Startup> _dbFixture;
+        private readonly GetAssetByAssetIdSteps _steps;
+        private readonly AssetsFixture _assetsFixture;
+
+        public GetAssetByAssetIdTests(DynamoDbIntegrationTests<Startup> dbFixture)
+        {
+            _dbFixture = dbFixture;
+            _assetsFixture = new AssetsFixture(_dbFixture.DynamoDbContext);
+            _steps = new GetAssetByAssetIdSteps(_dbFixture.Client);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private bool _disposed;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                if (null != _assetsFixture)
+                    _assetsFixture.Dispose();
+
+                _disposed = true;
+            }
+        }
+
+        [Fact]
+        public void ServiceReturnsNotFoundWhenEntityDoesntExist()
+        {
+            this.Given(g => _assetsFixture.GivenAnAssetThatDoesntExist())
+                .When(w => _steps.WhenTheGetApiIsCalled(_assetsFixture.PropertyReference))
+                .Then(t => _steps.ThenNotFoundIsReturned())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsEntityWhenExists()
+        {
+            this.Given(g => _assetsFixture.GivenAnAssetAlreadyExists())
+                .When(w => _steps.WhenTheGetApiIsCalled(_assetsFixture.PropertyReference))
+                .Then(t => _steps.ThenTheAssetDetailsAreReturned(_assetsFixture.Asset))
+                .BDDfy();
+        }
+    }
+}

--- a/AssetInformationApi.Tests/V1/E2ETests/Stories/GetAssetByAssetIdTests.cs
+++ b/AssetInformationApi.Tests/V1/E2ETests/Stories/GetAssetByAssetIdTests.cs
@@ -63,5 +63,16 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Stories
                 .Then(t => _steps.ThenTheAssetDetailsAreReturned(_assetsFixture.Asset))
                 .BDDfy();
         }
+
+        [Fact]
+        public void ServiceReturnsBadRequestWhenAssetIdContainsTags()
+        {
+            var stringWithTags = "Some string with <tag> in it.";
+
+            this.Given(g => _assetsFixture.GivenAnAssetThatDoesntExist())
+                .When(w => _steps.WhenTheGetApiIsCalled(stringWithTags))
+                .Then(t => _steps.ThenBadRequestIsReturned())
+                .BDDfy();
+        }
     }
 }

--- a/AssetInformationApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/AssetInformationApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -88,5 +88,46 @@ namespace AssetInformationApi.Tests.V1.Gateways
             response.Should().BeEquivalentTo(entity);
             _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.LoadAsync for id {request.Id}", Times.Once());
         }
+
+        [Fact]
+        public async Task GetAssetByAssetIdWhenEntityDoesntExistReturnsNull()
+        {
+            // Arrange
+            var query = new GetAssetByAssetIdRequest
+            {
+                AssetId = _fixture.Create<string>()
+            };
+
+            // Act
+            var response = await _classUnderTest.GetAssetByAssetId(query).ConfigureAwait(false);
+
+            // Assert
+            response.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GetAssetByAssetIdWhenEntityExistsReturnsEntity()
+        {
+            // Arrange
+            var entity = _fixture.Build<AssetDb>()
+                .With(x => x.VersionNumber, (int?) null)
+                .Create();
+
+            await InsertDataIntoDynamoDB(entity).ConfigureAwait(false);
+
+            var query = new GetAssetByAssetIdRequest
+            {
+                AssetId = entity.AssetId
+            };
+
+            // Act
+            var response = await _classUnderTest.GetAssetByAssetId(query).ConfigureAwait(false);
+
+            // Assert
+            response.Should().NotBeNull();
+            response.Should().BeEquivalentTo(entity.ToDomain());
+
+            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.QueryAsync for AssetId {query.AssetId}", Times.Once());
+        }
     }
 }

--- a/AssetInformationApi.Tests/V1/UseCase/GetAssetByAssetIdUseCaseTests.cs
+++ b/AssetInformationApi.Tests/V1/UseCase/GetAssetByAssetIdUseCaseTests.cs
@@ -26,8 +26,9 @@ namespace AssetInformationApi.Tests.V1.UseCase
             _classUnderTest = new GetAssetByAssetIdUseCase(_mockGateway.Object);
         }
 
+
         [Fact]
-        public async Task WhenCalledCallsGateway()
+        public async Task WhenResponseIsNullReturnsNull()
         {
             // Arrange
             var query = new GetAssetByAssetIdRequest
@@ -35,11 +36,39 @@ namespace AssetInformationApi.Tests.V1.UseCase
                 AssetId = _fixture.Create<string>()
             };
 
+            Asset gatewayResponse = null;
+
+            _mockGateway
+                .Setup(x => x.GetAssetByAssetId(It.IsAny<GetAssetByAssetIdRequest>()))
+                .ReturnsAsync(gatewayResponse);
+
             // Act
-            await _classUnderTest.ExecuteAsync(query).ConfigureAwait(false);
+            var response = await _classUnderTest.ExecuteAsync(query).ConfigureAwait(false);
 
             // Assert
-            _mockGateway.Verify(x => x.GetAssetByAssetId(query), Times.Once);
+            response.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task WhenEntityReturnedReturnsResponseObject()
+        {
+            // Arrange
+            Asset gatewayResponse = _fixture.Create<Asset>();
+
+            _mockGateway
+                .Setup(x => x.GetAssetByAssetId(It.IsAny<GetAssetByAssetIdRequest>()))
+                .ReturnsAsync(gatewayResponse);
+
+            var query = new GetAssetByAssetIdRequest
+            {
+                AssetId = gatewayResponse.AssetId
+            };
+
+            // Act
+            var response = await _classUnderTest.ExecuteAsync(query).ConfigureAwait(false);
+
+            // Assert
+            response.Should().BeEquivalentTo(gatewayResponse.ToResponse());
         }
     }
 }

--- a/AssetInformationApi.Tests/V1/UseCase/GetAssetByAssetIdUseCaseTests.cs
+++ b/AssetInformationApi.Tests/V1/UseCase/GetAssetByAssetIdUseCaseTests.cs
@@ -1,0 +1,45 @@
+using AssetInformationApi.V1.Boundary.Request;
+using AssetInformationApi.V1.Gateways;
+using AssetInformationApi.V1.UseCase;
+using AutoFixture;
+using FluentAssertions;
+using Hackney.Shared.Asset.Boundary.Response;
+using Hackney.Shared.Asset.Domain;
+using Hackney.Shared.Asset.Factories;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AssetInformationApi.Tests.V1.UseCase
+{
+    [Collection("LogCall collection")]
+    public class GetAssetByAssetIdUseCaseTests
+    {
+        private readonly Mock<IAssetGateway> _mockGateway;
+        private readonly GetAssetByAssetIdUseCase _classUnderTest;
+        private readonly Fixture _fixture = new Fixture();
+
+        public GetAssetByAssetIdUseCaseTests()
+        {
+            _mockGateway = new Mock<IAssetGateway>();
+            _classUnderTest = new GetAssetByAssetIdUseCase(_mockGateway.Object);
+        }
+
+        [Fact]
+        public async Task WhenCalledCallsGateway()
+        {
+            // Arrange
+            var query = new GetAssetByAssetIdRequest
+            {
+                AssetId = _fixture.Create<string>()
+            };
+
+            // Act
+            await _classUnderTest.ExecuteAsync(query).ConfigureAwait(false);
+
+            // Assert
+            _mockGateway.Verify(x => x.GetAssetByAssetId(query), Times.Once);
+        }
+    }
+}

--- a/AssetInformationApi/Startup.cs
+++ b/AssetInformationApi/Startup.cs
@@ -155,6 +155,7 @@ namespace AssetInformationApi
         private static void RegisterUseCases(IServiceCollection services)
         {
             services.AddScoped<IGetAssetByIdUseCase, GetAssetByIdUseCase>();
+            services.AddScoped<IGetAssetByAssetIdUseCase, GetAssetByAssetIdUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/AssetInformationApi/V1/Boundary/Request/GetAssetByAssetIdRequest.cs
+++ b/AssetInformationApi/V1/Boundary/Request/GetAssetByAssetIdRequest.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AssetInformationApi.V1.Boundary.Request
+{
+    public class GetAssetByAssetIdRequest
+    {
+        [FromRoute(Name = "assetId")]
+        public string AssetId { get; set; }
+    }
+}

--- a/AssetInformationApi/V1/Boundary/Request/Validation/GetAssetByAssetIdRequestValidator.cs
+++ b/AssetInformationApi/V1/Boundary/Request/Validation/GetAssetByAssetIdRequestValidator.cs
@@ -1,4 +1,6 @@
 using FluentValidation;
+using Hackney.Core.Validation;
+using Hackney.Shared.Tenure.Boundary.Requests.Validation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,6 +15,9 @@ namespace AssetInformationApi.V1.Boundary.Request.Validation
             RuleFor(x => x.AssetId)
                 .NotNull()
                 .NotEmpty();
+
+            RuleFor(x => x.AssetId).NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure);
         }
     }
 }

--- a/AssetInformationApi/V1/Boundary/Request/Validation/GetAssetByAssetIdRequestValidator.cs
+++ b/AssetInformationApi/V1/Boundary/Request/Validation/GetAssetByAssetIdRequestValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AssetInformationApi.V1.Boundary.Request.Validation
+{
+    public class GetAssetByAssetIdRequestValidator : AbstractValidator<GetAssetByAssetIdRequest>
+    {
+        public GetAssetByAssetIdRequestValidator()
+        {
+            RuleFor(x => x.AssetId)
+                .NotNull()
+                .NotEmpty();
+        }
+    }
+}

--- a/AssetInformationApi/V1/Controllers/AssetInformationApiController.cs
+++ b/AssetInformationApi/V1/Controllers/AssetInformationApiController.cs
@@ -16,9 +16,14 @@ namespace AssetInformationApi.V1.Controllers
     public class AssetInformationApiController : BaseController
     {
         private readonly IGetAssetByIdUseCase _getAssetByIdUseCase;
-        public AssetInformationApiController(IGetAssetByIdUseCase getAssetByIdUseCase)
+        private readonly IGetAssetByAssetIdUseCase _getAssetByAssetIdUseCase;
+
+        public AssetInformationApiController(
+            IGetAssetByIdUseCase getAssetByIdUseCase,
+            IGetAssetByAssetIdUseCase getAssetByAssetIdUseCase)
         {
             _getAssetByIdUseCase = getAssetByIdUseCase;
+            _getAssetByAssetIdUseCase = getAssetByAssetIdUseCase;
         }
 
         /// <summary>
@@ -38,6 +43,27 @@ namespace AssetInformationApi.V1.Controllers
         {
             var result = await _getAssetByIdUseCase.ExecuteAsync(query).ConfigureAwait(false);
             if (result == null) return NotFound(query.Id);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Retrieves the asset with the supplied assetId. Endpoint intended for RepairsAPI
+        /// </summary>
+        /// <response code="200">Successfully retrieved details for the specified AssetId</response>
+        /// <response code="404">No tenure information found for the specified AssetId</response>
+        /// <response code="500">Internal server error</response>
+        [ProducesResponseType(typeof(AssetResponseObject), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [HttpGet]
+        [Route("assetId/{assetId}")]
+        [LogCall(LogLevel.Information)]
+        public async Task<IActionResult> GetAssetByAssetId([FromRoute] GetAssetByAssetIdRequest query)
+        {
+            var result = await _getAssetByAssetIdUseCase.ExecuteAsync(query).ConfigureAwait(false);
+            if (result == null) return NotFound(query.AssetId);
+
             return Ok(result);
         }
     }

--- a/AssetInformationApi/V1/Gateways/DynamoDbGateway.cs
+++ b/AssetInformationApi/V1/Gateways/DynamoDbGateway.cs
@@ -5,6 +5,8 @@ using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.Asset.Factories;
 using Hackney.Shared.Asset.Infrastructure;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace AssetInformationApi.V1.Gateways
@@ -26,6 +28,24 @@ namespace AssetInformationApi.V1.Gateways
             _logger.LogDebug($"Calling IDynamoDBContext.LoadAsync for id {query.Id}");
             var result = await _dynamoDbContext.LoadAsync<AssetDb>(query.Id).ConfigureAwait(false);
             return result?.ToDomain();
+        }
+
+        [LogCall]
+        public async Task<Asset> GetAssetByAssetId(GetAssetByAssetIdRequest query)
+        {
+            _logger.LogDebug($"Calling IDynamoDBContext.QueryAsync for AssetId {query.AssetId}");
+
+            var config = new DynamoDBOperationConfig
+            {
+                IndexName = "AssetId"
+            };
+
+            var search = _dynamoDbContext.QueryAsync<AssetDb>(query.AssetId, config);
+
+            var response = await search.GetNextSetAsync().ConfigureAwait(false);
+            if (response.Count == 0) return null;
+
+            return response.First().ToDomain();
         }
     }
 }

--- a/AssetInformationApi/V1/Gateways/IAssetGateway.cs
+++ b/AssetInformationApi/V1/Gateways/IAssetGateway.cs
@@ -8,5 +8,6 @@ namespace AssetInformationApi.V1.Gateways
     public interface IAssetGateway
     {
         Task<Asset> GetAssetByIdAsync(GetAssetByIdRequest query);
+        Task<Asset> GetAssetByAssetId(GetAssetByAssetIdRequest query);
     }
 }

--- a/AssetInformationApi/V1/UseCase/GetAssetByAssetIdUseCase.cs
+++ b/AssetInformationApi/V1/UseCase/GetAssetByAssetIdUseCase.cs
@@ -23,7 +23,9 @@ namespace AssetInformationApi.V1.UseCase
         [LogCall]
         public async Task<AssetResponseObject> ExecuteAsync(GetAssetByAssetIdRequest query)
         {
-            return (await _gateway.GetAssetByAssetId(query).ConfigureAwait(false)).ToResponse();
+            var asset = await _gateway.GetAssetByAssetId(query).ConfigureAwait(false);
+
+            return asset?.ToResponse();
         }
     }
 }

--- a/AssetInformationApi/V1/UseCase/GetAssetByAssetIdUseCase.cs
+++ b/AssetInformationApi/V1/UseCase/GetAssetByAssetIdUseCase.cs
@@ -1,0 +1,29 @@
+using AssetInformationApi.V1.Boundary.Request;
+using AssetInformationApi.V1.Gateways;
+using AssetInformationApi.V1.UseCase.Interfaces;
+using Hackney.Core.Logging;
+using Hackney.Shared.Asset.Boundary.Response;
+using Hackney.Shared.Asset.Factories;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AssetInformationApi.V1.UseCase
+{
+    public class GetAssetByAssetIdUseCase : IGetAssetByAssetIdUseCase
+    {
+        private readonly IAssetGateway _gateway;
+
+        public GetAssetByAssetIdUseCase(IAssetGateway gateway)
+        {
+            _gateway = gateway;
+        }
+
+        [LogCall]
+        public async Task<AssetResponseObject> ExecuteAsync(GetAssetByAssetIdRequest query)
+        {
+            return (await _gateway.GetAssetByAssetId(query).ConfigureAwait(false)).ToResponse();
+        }
+    }
+}

--- a/AssetInformationApi/V1/UseCase/Interfaces/IGetAssetByAssetIdUseCase.cs
+++ b/AssetInformationApi/V1/UseCase/Interfaces/IGetAssetByAssetIdUseCase.cs
@@ -1,0 +1,14 @@
+using AssetInformationApi.V1.Boundary.Request;
+using Hackney.Shared.Asset.Boundary.Response;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AssetInformationApi.V1.UseCase.Interfaces
+{
+    public interface IGetAssetByAssetIdUseCase
+    {
+        Task<AssetResponseObject> ExecuteAsync(GetAssetByAssetIdRequest query);
+    }
+}

--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -29,6 +29,14 @@ resource "aws_dynamodb_table" "assetinformationapi_dynamodb_table" {
     projection_type = "ALL"
   }
 
+  global_secondary_index {
+    name            = "AssetId"
+    hash_key        = "assetId"
+    write_capacity  = 0
+    read_capacity   = 10
+    projection_type = "ALL"
+  }
+
   tags = merge(
     local.default_tags,
     { BackupPolicy = "Dev" }

--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -29,6 +29,14 @@ resource "aws_dynamodb_table" "assetinformationapi_dynamodb_table" {
     projection_type = "ALL"
   }
 
+  global_secondary_index {
+    name            = "AssetId"
+    hash_key        = "assetId"
+    write_capacity  = 0
+    read_capacity   = 10
+    projection_type = "ALL"
+  }
+
   tags = merge(
     local.default_tags,
     { BackupPolicy = "Prod" }

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -29,6 +29,14 @@ resource "aws_dynamodb_table" "assetinformationapi_dynamodb_table" {
     projection_type = "ALL"
   }
 
+  global_secondary_index {
+    name            = "AssetId"
+    hash_key        = "assetId"
+    write_capacity  = 0
+    read_capacity   = 10
+    projection_type = "ALL"
+  }
+
   tags = merge(
     local.default_tags,
     { BackupPolicy = "Stg" }


### PR DESCRIPTION
Create new endpoint `/assets/assetId/{assetId}` to query an asset by its assetId.

This endpoint is required for the the Repairs API to integrate with the Asset Information API.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly