### PR TITLE
MR-692 - Modified GetIfMatchFromHeader to be more flexible when receiving if-match header

### DIFF
--- a/AssetInformationApi/V1/Controllers/AssetInformationApiController.cs
+++ b/AssetInformationApi/V1/Controllers/AssetInformationApiController.cs
@@ -166,8 +166,16 @@ namespace AssetInformationApi.V1.Controllers
         {
             var header = HttpContext.Request.Headers.GetHeaderValue(HeaderConstants.IfMatch);
 
+            int numericValue;
+
             if (header == null)
                 return null;
+
+            if (header.GetType() == typeof(string))
+            {
+                if (int.TryParse(header, out numericValue))
+                    return numericValue;
+            }
 
             _ = EntityTagHeaderValue.TryParse(header, out var entityTagHeaderValue);
 
@@ -176,7 +184,7 @@ namespace AssetInformationApi.V1.Controllers
 
             var version = entityTagHeaderValue.Tag.Replace("\"", string.Empty);
 
-            if (int.TryParse(version, out var numericValue))
+            if (int.TryParse(version, out numericValue))
                 return numericValue;
 
             return null;


### PR DESCRIPTION
Modified GetIfMatchFromHeader to be more flexible when receiving if-match header, in regards to its type. 

As this method was already used by the old PatchAsset endpoint, the existing functionality has not been changed. An extra piece of functionality has been added so that the if-match header can have a different type (this would be specific for the new PatchAssetAddress endpoint).