### PR TITLE
Fix the Get Asset by (Guid) Id returning Business Layer rather than P…

### DIFF
--- a/AssetInformationApi.Tests/V1/Controllers/AssetInformationApiControllerTests.cs
+++ b/AssetInformationApi.Tests/V1/Controllers/AssetInformationApiControllerTests.cs
@@ -112,13 +112,14 @@ namespace AssetInformationApi.Tests.V1.Controllers
         [Fact]
         public async Task GetTenureWithValidIdReturnsOKResponse()
         {
-            var tenureResponse = _fixture.Create<Asset>();
-            var request = ConstructRequest(tenureResponse.Id);
-            _mockGetAssetByIdUseCase.Setup(x => x.ExecuteAsync(request)).ReturnsAsync(tenureResponse);
+            var tenureDomain = _fixture.Create<Asset>();
+            var tenureResponse = tenureDomain.ToResponse();
+            var request = ConstructRequest(tenureDomain.Id);
+            _mockGetAssetByIdUseCase.Setup(x => x.ExecuteAsync(request)).ReturnsAsync(tenureDomain);
 
             var response = await _classUnderTest.GetAssetById(request).ConfigureAwait(false);
             response.Should().BeOfType(typeof(OkObjectResult));
-            (response as OkObjectResult).Value.Should().Be(tenureResponse);
+            (response as OkObjectResult).Value.Should().BeEquivalentTo(tenureResponse);
         }
 
         [Fact]
@@ -168,6 +169,8 @@ namespace AssetInformationApi.Tests.V1.Controllers
         {
             // Arrange
             var useCaseResponse = _fixture.Create<Asset>();
+            var expectedControllerResponse = useCaseResponse.ToResponse();
+
             _mockGetAssetByIdUseCase
                 .Setup(x => x.ExecuteAsync(It.IsAny<GetAssetByIdRequest>()))
                 .ReturnsAsync(useCaseResponse);
@@ -186,9 +189,8 @@ namespace AssetInformationApi.Tests.V1.Controllers
 
             // Assert
             response.Should().BeOfType(typeof(OkObjectResult));
-            (response as OkObjectResult).Value.Should().BeOfType(typeof(Asset));
 
-            ((response as OkObjectResult).Value as Asset).Should().BeEquivalentTo(useCaseResponse);
+            ((response as OkObjectResult).Value).Should().BeEquivalentTo(expectedControllerResponse);
         }
 
         [Fact]

--- a/AssetInformationApi/V1/Controllers/AssetInformationApiController.cs
+++ b/AssetInformationApi/V1/Controllers/AssetInformationApiController.cs
@@ -64,16 +64,18 @@ namespace AssetInformationApi.V1.Controllers
         [LogCall(LogLevel.Information)]
         public async Task<IActionResult> GetAssetById([FromRoute] GetAssetByIdRequest query)
         {
-            var result = await _getAssetByIdUseCase.ExecuteAsync(query).ConfigureAwait(false);
-            if (result == null) return NotFound(query.Id);
+            var useCaseResult = await _getAssetByIdUseCase.ExecuteAsync(query).ConfigureAwait(false);
+            if (useCaseResult == null) return NotFound(query.Id);
+
+            var endpointResponse = useCaseResult.ToResponse();
 
             var eTag = string.Empty;
-            if (result.VersionNumber.HasValue)
-                eTag = result.VersionNumber.ToString();
+            if (endpointResponse.VersionNumber.HasValue)
+                eTag = endpointResponse.VersionNumber.ToString();
 
             HttpContext.Response.Headers.Add(HeaderConstants.ETag, EntityTagHeaderValue.Parse($"\"{eTag}\"").Tag);
 
-            return Ok(result);
+            return Ok(endpointResponse);
         }
 
         /// <summary>


### PR DESCRIPTION
# What:
- Made the 'Get Asset by (Guid) Id' endpoint return a 'Response' object instead of 'Domain'.

# Why:
There currently exists a front-end bug, where within the property page within the MMH web ui application, the Tenure is being displayed as 'Inactive' while it was actually 'Active'. This is because the `'IsActive'` field under the Tenure object under the Asset object is not being included in the API response.

The surface level cause of it is that the endpoint's returned object has an `[IgnoreJson]` attribute over it making it excluded from the response.

The Root level cause is that the returned object is a Domain (business layer) entity. Had this entity been mapped to the Response object, which is already together with the Factory method available within the same `Hackney.Shared.Assets` package as the Domain level entity, the `'IsActive'` field would have been returned fine.

Also, this layer separation fix is a must have to conform to Hackney standard architecture.

# Notes:
 - This shouldn't get merged until the issues with the `Hackney.Shared.Asset` Response model get resolved.
 // TODO: tag the issues, once they get created.