### PR TITLE
MR-692 - Change to asset version checking in Asset API

### DIFF
--- a/AssetInformationApi/V1/Gateways/DynamoDbGateway.cs
+++ b/AssetInformationApi/V1/Gateways/DynamoDbGateway.cs
@@ -85,8 +85,13 @@ namespace AssetInformationApi.V1.Gateways
             var existingAsset = await _dynamoDbContext.LoadAsync<AssetDb>(assetId).ConfigureAwait(false);
             if (existingAsset == null) return null;
 
-            if (ifMatch != existingAsset.VersionNumber)
+            if (ifMatch != existingAsset.VersionNumber && existingAsset.VersionNumber != null)
                 throw new VersionNumberConflictException(ifMatch, existingAsset.VersionNumber);
+
+            if (existingAsset.VersionNumber == null)
+            {
+                existingAsset.VersionNumber = 0;
+            }
 
             var response = _updater.UpdateEntity(existingAsset, requestBody, assetRequestObject);
 


### PR DESCRIPTION
Issue: Patching asset when asset versionNumber is null triggers asset version invalid error.

Attempting to patch an existing asset with null versionNumber:

- if a version (as If-match header) is sent, it says 'version does not match {null}'
- if ‘null’ version (as If-match header) is sent, we receive 204, but no change is made to the asset.

The intended fix in this PR:

If we try and patch an asset with a 'null' versionNumber, then we do NOT throw a 409 error. We change the existing asset's version and proceed with the update of the asset address.