### PR TITLE
MR-692 Added Google group specific authorization for PatchAsset endpoint

### DIFF
--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -17,7 +17,9 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />

--- a/AssetInformationApi.Tests/V1/E2ETests/Steps/EditAssetSteps.cs
+++ b/AssetInformationApi.Tests/V1/E2ETests/Steps/EditAssetSteps.cs
@@ -120,6 +120,12 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Steps
             responseContent.Should().Contain($"The version number supplied ({sentVersionNumberString}) does not match the current value on the entity (0).");
         }
 
+        public async Task ThenUnauthorizedIsReturned()
+        {
+            _lastResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+
         private static void ShouldHaveErrorFor(JEnumerable<JToken> errors, string propertyName, string errorCode = null)
         {
             var error = errors.FirstOrDefault(x => (x.Path.Split('.').Last().Trim('\'', ']')) == propertyName) as JProperty;

--- a/AssetInformationApi.Tests/V1/E2ETests/Stories/EditAssetAddressTests.cs
+++ b/AssetInformationApi.Tests/V1/E2ETests/Stories/EditAssetAddressTests.cs
@@ -58,6 +58,7 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void AddressEditServiceReturns204AndUpdatesDatabase()
         {
+            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "mmh-asset-admin,e2e-testing-development,e2e-testing-staging");
             this.Given(g => _assetFixture.GivenAnAssetAlreadyExists())
                 .Then(t => _assetFixture.CreateEditAssetAddressObject())
                 .When(w => _steps.WhenEditAssetAddressApiIsCalled(_assetFixture.AssetId, _assetFixture.EditAssetAddress))
@@ -70,6 +71,8 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceReturns400BadRequest()
         {
+            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "mmh-asset-admin,e2e-testing-development,e2e-testing-staging");
+
             var invalidRequestObject = "bad-data";
 
             this.Given(g => _assetFixture.GivenAnAssetAlreadyExists())
@@ -81,6 +84,8 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceReturns400BadRequestForFailedValidation()
         {
+            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "mmh-asset-admin,e2e-testing-development,e2e-testing-staging");
+
             var requestWithoutAddressLine1 = new EditAssetAddressRequest
             {
                 ParentAssetIds = Guid.NewGuid().ToString(),
@@ -103,6 +108,8 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceReturnsNotFoundResponse()
         {
+            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "mmh-asset-admin,e2e-testing-development,e2e-testing-staging");
+
             var randomId = Guid.NewGuid();
             var requestObject = CreateValidRequestObject();
 

--- a/AssetInformationApi.Tests/V1/E2ETests/Stories/EditAssetAddressTests.cs
+++ b/AssetInformationApi.Tests/V1/E2ETests/Stories/EditAssetAddressTests.cs
@@ -58,7 +58,7 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void AddressEditServiceReturns204AndUpdatesDatabase()
         {
-            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "mmh-asset-admin,e2e-testing-development,e2e-testing-staging");
+            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "e2e-testing");
             this.Given(g => _assetFixture.GivenAnAssetAlreadyExists())
                 .Then(t => _assetFixture.CreateEditAssetAddressObject())
                 .When(w => _steps.WhenEditAssetAddressApiIsCalled(_assetFixture.AssetId, _assetFixture.EditAssetAddress))
@@ -71,7 +71,7 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceReturns400BadRequest()
         {
-            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "mmh-asset-admin,e2e-testing-development,e2e-testing-staging");
+            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "e2e-testing");
 
             var invalidRequestObject = "bad-data";
 
@@ -84,7 +84,7 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceReturns400BadRequestForFailedValidation()
         {
-            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "mmh-asset-admin,e2e-testing-development,e2e-testing-staging");
+            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "e2e-testing");
 
             var requestWithoutAddressLine1 = new EditAssetAddressRequest
             {
@@ -108,7 +108,7 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceReturnsNotFoundResponse()
         {
-            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "mmh-asset-admin,e2e-testing-development,e2e-testing-staging");
+            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "e2e-testing");
 
             var randomId = Guid.NewGuid();
             var requestObject = CreateValidRequestObject();

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -17,10 +17,11 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.2" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.3" />
+    <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.49.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />

--- a/AssetInformationApi/V1/Controllers/AssetInformationApiController.cs
+++ b/AssetInformationApi/V1/Controllers/AssetInformationApiController.cs
@@ -17,7 +17,7 @@ using HeaderConstants = AssetInformationApi.V1.Infrastructure.HeaderConstants;
 using System.Net.Http.Headers;
 using AssetInformationApi.V1.Infrastructure.Exceptions;
 using Hackney.Shared.Asset.Boundary.Request;
-
+using Hackney.Core.Authorization;
 
 namespace AssetInformationApi.V1.Controllers
 {
@@ -143,6 +143,7 @@ namespace AssetInformationApi.V1.Controllers
         [HttpPatch]
         [Route("{id}/address")]
         [LogCall(LogLevel.Information)]
+        [AuthorizeEndpointByGroups("ASSET_ADMIN_GROUPS")]
         public async Task<IActionResult> PatchAssetAddress([FromRoute] EditAssetByIdRequest query, [FromBody] EditAssetAddressRequest asset)
         {
             var bodyText = await HttpContext.Request.GetRawBodyStringAsync().ConfigureAwait(false);

--- a/AssetInformationApi/serverless.yml
+++ b/AssetInformationApi/serverless.yml
@@ -24,7 +24,7 @@ functions:
     role: lambdaExecutionRole
     environment:
       ASSET_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/asset/arn}
-      ASSET_ADMIN_GROUPS: ${ssm:/tl-housing/${self:provider.stage}/asset-admin-allowed-groups}
+      ASSET_ADMIN_GROUPS: ${ssm:/ta-housing/${self:provider.stage}/asset-api-admin-allowed-groups}
     events:
       - http:
           path: /{proxy+}

--- a/AssetInformationApi/serverless.yml
+++ b/AssetInformationApi/serverless.yml
@@ -24,6 +24,7 @@ functions:
     role: lambdaExecutionRole
     environment:
       ASSET_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/asset/arn}
+      ASSET_ADMIN_GROUPS: ${ssm:/tl-housing/${self:provider.stage}/asset-admin-allowed-groups}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
Only a specific set of users should be able to patch assets from MMH. These are users in the group 'mmh-asset-admin'.

Added Google group specific authorization for PatchAsset endpoint.

To add Hackney.Core.Authorization, I had to update the version of Hackney.Core.JWT.