### PR TITLE
MR-698 - Updated version of Hackney.Shared.Asset from 0.25 to 0.27

### DIFF
--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.25.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.27.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.25.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.27.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" />


### PR DESCRIPTION
As part of the 'New asset' MMH feature, this PR updates version the of Hackney.Shared.Asset from 0.25 to 0.27 in this solution.

Following the below PRs...

- https://github.com/LBHackney-IT/asset-shared/pull/29
- https://github.com/LBHackney-IT/asset-shared/pull/30

...the AssetDb object has been changed, allowing some properties to be nullable, therefore avoiding them defaulting to values of 0 or 'false' (for int's and boolean's respectively) which could be misleading. For more context see PR 29's description.