### PR TITLE
MR-698 - Implemented IgnoreValueDefaultOnSerialize to avoid default values being saved to Db (alternative to updating the Hackney.Shared.Asset pkg)

### DIFF
--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.25.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.28.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.27.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.25.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.25.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.28.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" />

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.27.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.25.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" />

--- a/AssetInformationApi/Startup.cs
+++ b/AssetInformationApi/Startup.cs
@@ -68,6 +68,7 @@ namespace AssetInformationApi
                 .AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault;
                 });
 
             services.AddFluentValidation(Assembly.GetAssembly(typeof(EditAssetAddressRequestValidator)));


### PR DESCRIPTION
As the change in PR #29 (allowing AssetDb properties to be null) seems to have potentially major repercussions on Hackney apps that use the Hackney.Asset.Shared package, we have been looking into an alternative way to prevent properties that are not captured in the 'New Asset' form, to be saved in the database with default values such as 'false' for boolean and '0' for int types.

Default types C# docs:
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/default-values

Docs about the newly added JsonSerializerOptions option to Asset API:
https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/ignore-properties?pivots=dotnet-6-0#ignore-all-default-value-properties

- Added JsonIgnoreCondition.WhenWritingDefault JsonSerializerOptions in Startup.cs
- Upgraded Hackney.Core.Testing.Shared package to version 0.28 (this version undoes the changes introduced by 0.27, so essentially it's the same as 0.25) - This step is required for me to test that the above change has had the desired effect.

### Note:
**Apps that use Asset API may need to upgrade Hackney.Core.Testing.Shared to version 0.28 (I plan to release this only to development for testing purposes, to start with).**