### PR TITLE
MR-698 - Changed JsonSerializerOptions.DefaultIgnoreCondition from JsonIgnoreCondition.WhenWritingDefault to JsonIgnoreCondition.WhenWritingNull

### DIFF
--- a/AssetInformationApi/Startup.cs
+++ b/AssetInformationApi/Startup.cs
@@ -68,7 +68,7 @@ namespace AssetInformationApi
                 .AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
-                    options.JsonSerializerOptions.IgnoreNullValues = true;
+                    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
                 });
 
             services.AddFluentValidation(Assembly.GetAssembly(typeof(EditAssetAddressRequestValidator)));

--- a/AssetInformationApi/Startup.cs
+++ b/AssetInformationApi/Startup.cs
@@ -68,7 +68,7 @@ namespace AssetInformationApi
                 .AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
-                    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault;
+                    options.JsonSerializerOptions.IgnoreNullValues = true;
                 });
 
             services.AddFluentValidation(Assembly.GetAssembly(typeof(EditAssetAddressRequestValidator)));


### PR DESCRIPTION
Changed `JsonSerializerOptions.DefaultIgnoreCondition` from `JsonIgnoreCondition.WhenWritingDefault` to `JsonIgnoreCondition.WhenWritingNull` as the current configuration in Startup.cs does not allow you to send payloads with null values.

Example:

Sending the following payload:

```
{
    "id": "ec437b0c-d7b1-46e8-923a-0e1471fa26f5",
    "assetId": "2404TEST",
    "assetType": "Estate",
    "parentAssetIds": "",
    "isActive": true,
    "assetLocation": {
        "floorNo": "",
        "totalBlockFloors": null,
        "parentAssets": []
    },
    "assetAddress": {
        "uprn": "",
        "addressLine1": "123 Test Estate (CAN BE DELETED)",
        "addressLine2": "",
        "addressLine3": "",
        "addressLine4": "",
        "postCode": "E5 9HL"
    },
    "assetManagement": {
        "agent": "",
        "areaOfficeName": "",
        "isCouncilProperty": true,
        "managingOrganisation": "London Borough of Hackney",
        "isTMOManaged": false,
        "managingOrganisationId": "c01e3146-e630-c2cd-e709-18ef57bf3724"
    },
    "assetCharacteristics": {
        "numberOfBedrooms": null,
        "numberOfLivingRooms": null,
        "yearConstructed": "",
        "windowType": "",
        "numberOfLifts": null
    }
}
```

Returns the following error:

`{
    "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
    "title": "One or more validation errors occurred.",
    "status": 400,
    "traceId": "00-0c62d0fce4a6e13b344ffab5d61475fc-cb06156727fcc7bf-00",
    "errors": {
        "$.assetLocation.totalBlockFloors": [
            "The JSON value could not be converted to System.Int32. Path: $.assetLocation.totalBlockFloors | LineNumber: 0 | BytePositionInLine: 176."
        ]
    }
}`