### PR TITLE
Upgrade the Asset-Shared version to v0.31.0 for extra Asset Character…

### DIFF
--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.30.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.31.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AssetInformationApi.Tests/V1/E2ETests/Steps/EditAssetSteps.cs
+++ b/AssetInformationApi.Tests/V1/E2ETests/Steps/EditAssetSteps.cs
@@ -167,7 +167,7 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Steps
             var databaseResponse = await _dbContext.LoadAsync<AssetDb>(assetFixture.AssetId).ConfigureAwait(false);
 
             databaseResponse.Id.Should().Be(assetFixture.ExistingAsset.Id);
-            databaseResponse.AssetCharacteristics.ToString().Should().Be(assetFixture.EditAsset.AssetCharacteristics.ToString());
+            databaseResponse.AssetCharacteristics.ToString().Should().Be(assetFixture.EditAsset.AssetCharacteristics.ToDatabase().ToString());
             databaseResponse.AssetManagement.ToString().Should().Be(assetFixture.EditAsset.AssetManagement.ToString());
             databaseResponse.ParentAssetIds.Should().Be(assetFixture.EditAsset.ParentAssetIds);
             databaseResponse.RootAsset.Should().Be(assetFixture.EditAsset.RootAsset);

--- a/AssetInformationApi.Tests/V1/Factories/RequestFactoryTests.cs
+++ b/AssetInformationApi.Tests/V1/Factories/RequestFactoryTests.cs
@@ -1,0 +1,52 @@
+using AutoFixture;
+using Hackney.Shared.Asset.Boundary.Request;
+using AssetInformationApi.V1.Factories;
+using Hackney.Shared.Asset.Factories;
+using Xunit;
+using FluentAssertions;
+
+namespace AssetInformationApi.Tests.V1.Factories
+{
+    public class RequestFactoryTests
+    {
+        private readonly Fixture _fixture = new Fixture();
+
+        [Fact]
+        public void EditAssetRequestCorrectlyMapsToItsDatabaseLayerEquivalent()
+        {
+            // arrange
+            var editAssetRequest = _fixture.Create<EditAssetRequest>();
+
+            // act
+            var editAssetDatabase = editAssetRequest.ToDatabase();
+
+            // assert
+            editAssetDatabase.RootAsset.Should().Be(editAssetRequest.RootAsset);
+            editAssetDatabase.ParentAssetIds.Should().Be(editAssetRequest.ParentAssetIds);
+            editAssetDatabase.IsActive.Should().Be(editAssetRequest.IsActive);
+            editAssetDatabase.AssetLocation.Should().Be(editAssetRequest.AssetLocation);
+            editAssetDatabase.AssetManagement.Should().Be(editAssetRequest.AssetManagement);
+            editAssetDatabase.AssetCharacteristics.Should().BeEquivalentTo(editAssetRequest.AssetCharacteristics.ToDatabase());
+        }
+
+        [Fact]
+        public void EditAssetAddressRequestCorrectlyMapsToItsDatabaseLayerEquivalent()
+        {
+            // arrange
+            var editAssetAddressRequest = _fixture.Create<EditAssetAddressRequest>();
+
+            // act
+            var editAssetAddressDatabase = editAssetAddressRequest.ToDatabase();
+
+            // assert
+            editAssetAddressDatabase.AssetAddress.Should().Be(editAssetAddressRequest.AssetAddress);
+
+            editAssetAddressDatabase.RootAsset.Should().Be(editAssetAddressRequest.RootAsset);
+            editAssetAddressDatabase.ParentAssetIds.Should().Be(editAssetAddressRequest.ParentAssetIds);
+            editAssetAddressDatabase.IsActive.Should().Be(editAssetAddressRequest.IsActive);
+            editAssetAddressDatabase.AssetLocation.Should().Be(editAssetAddressRequest.AssetLocation);
+            editAssetAddressDatabase.AssetManagement.Should().Be(editAssetAddressRequest.AssetManagement);
+            editAssetAddressDatabase.AssetCharacteristics.Should().BeEquivalentTo(editAssetAddressRequest.AssetCharacteristics.ToDatabase());
+        }
+    }
+}

--- a/AssetInformationApi.Tests/V1/UseCase/EditAssetUseCaseTests.cs
+++ b/AssetInformationApi.Tests/V1/UseCase/EditAssetUseCaseTests.cs
@@ -65,6 +65,8 @@ namespace AssetInformationApi.Tests.V1.UseCase
                 UpdatedEntity = _fixture.Create<AssetDb>()
             };
 
+            var expectedAssetCharacteristics = gatewayResponse.UpdatedEntity.AssetCharacteristics.ToDomain().ToResponse();
+
             _mockGateway.Setup(x => x.EditAssetDetails(It.IsAny<Guid>(), It.IsAny<EditAssetRequest>(), It.IsAny<string>(), It.IsAny<int?>())).ReturnsAsync(gatewayResponse);
 
             var response = await _classUnderTest.ExecuteAsync(mockQuery, mockRequestObject, mockRawBody, mockToken, null).ConfigureAwait(false);
@@ -72,7 +74,7 @@ namespace AssetInformationApi.Tests.V1.UseCase
             response.Should().NotBeNull();
             response.Should().BeOfType(typeof(AssetResponseObject));
 
-            response.AssetCharacteristics.Should().Be(gatewayResponse.UpdatedEntity.AssetCharacteristics);
+            response.AssetCharacteristics.Should().BeEquivalentTo(expectedAssetCharacteristics);
             response.AssetManagement.Should().Be(gatewayResponse.UpdatedEntity.AssetManagement);
             response.Id.Should().Be(gatewayResponse.UpdatedEntity.Id);
         }

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.30.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.31.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" />

--- a/AssetInformationApi/V1/Factories/RequestFactory.cs
+++ b/AssetInformationApi/V1/Factories/RequestFactory.cs
@@ -1,0 +1,40 @@
+using AssetInformationApi.V1.Infrastructure;
+using Hackney.Shared.Asset.Boundary.Request;
+using Hackney.Shared.Asset.Factories;
+
+namespace AssetInformationApi.V1.Factories
+{
+    public static class EntityFactory
+    {
+        public static EditAssetDatabase ToDatabase(this EditAssetRequest domainEntity)
+        {
+            if (domainEntity == null) return null;
+
+            return new EditAssetDatabase
+            {
+                RootAsset = domainEntity.RootAsset,
+                ParentAssetIds = domainEntity.ParentAssetIds,
+                IsActive = domainEntity.IsActive,
+                AssetLocation = domainEntity.AssetLocation,
+                AssetManagement = domainEntity.AssetManagement,
+                AssetCharacteristics = domainEntity.AssetCharacteristics.ToDatabase()
+            };
+        }
+
+        public static EditAssetAddressDatabase ToDatabase(this EditAssetAddressRequest domainEntity)
+        {
+            if (domainEntity == null) return null;
+
+            return new EditAssetAddressDatabase
+            {
+                AssetAddress = domainEntity.AssetAddress,
+                RootAsset = domainEntity.RootAsset,
+                ParentAssetIds = domainEntity.ParentAssetIds,
+                IsActive = domainEntity.IsActive,
+                AssetLocation = domainEntity.AssetLocation,
+                AssetManagement = domainEntity.AssetManagement,
+                AssetCharacteristics = domainEntity.AssetCharacteristics.ToDatabase()
+            };
+        }
+    }
+}

--- a/AssetInformationApi/V1/Gateways/IAssetGateway.cs
+++ b/AssetInformationApi/V1/Gateways/IAssetGateway.cs
@@ -13,6 +13,6 @@ namespace AssetInformationApi.V1.Gateways
         Task<Asset> GetAssetByIdAsync(GetAssetByIdRequest query);
         Task<Asset> GetAssetByAssetId(GetAssetByAssetIdRequest query);
         Task<Asset> AddAsset(AssetDb asset);
-        Task<UpdateEntityResult<AssetDb>> EditAssetDetails<T>(Guid assetId, T assetRequestObject, string requestBody, int? ifMatch) where T : class;
+        Task<UpdateEntityResult<AssetDb>> EditAssetDetails(Guid assetId, EditAssetRequest assetRequestObject, string requestBody, int? ifMatch);
     }
 }

--- a/AssetInformationApi/V1/Infrastructure/EditAssetAddressDatabase.cs
+++ b/AssetInformationApi/V1/Infrastructure/EditAssetAddressDatabase.cs
@@ -1,0 +1,9 @@
+using Hackney.Shared.Asset.Domain;
+
+namespace AssetInformationApi.V1.Infrastructure
+{
+    public class EditAssetAddressDatabase : EditAssetDatabase
+    {
+        public AssetAddress AssetAddress { get; set; }
+    }
+}

--- a/AssetInformationApi/V1/Infrastructure/EditAssetDatabase.cs
+++ b/AssetInformationApi/V1/Infrastructure/EditAssetDatabase.cs
@@ -1,0 +1,20 @@
+using Hackney.Shared.Asset.Domain;
+using Hackney.Shared.Asset.Infrastructure;
+
+namespace AssetInformationApi.V1.Infrastructure
+{
+    public class EditAssetDatabase
+    {
+        public string RootAsset { get; set; }
+
+        public string ParentAssetIds { get; set; }
+
+        public bool IsActive { get; set; }
+        public AssetLocation AssetLocation { get; set; }
+
+        public AssetManagement AssetManagement { get; set; }
+
+        public AssetCharacteristicsDb AssetCharacteristics { get; set; }
+
+    }
+}


### PR DESCRIPTION
# What:
 - An upgrade to the `Shared.Asset` package version from `v0.27.0` to `v0.31.0`.

# Why:
 - We need more property characteristics fields _(like number of single beds, double beds, etc.)_ more on that within [this PR's](https://github.com/LBHackney-IT/asset-information-listener/pull/40) description.

# Notes:
 - The package changes are [here](https://github.com/LBHackney-IT/asset-shared/pull/36).
 - The modified _(within this PR)_ functionality of this application has been coupled with poorly separated architecture layers of the `AssetCharacteristics` model. This has required some changes to at bare minimum decouple the Domain layer from the Database regarding that particular model. Due to some generics/inheritance/system.reflections mash, this has required minor changes to the `EditAssetDetails` GW method. The inheritance choice for the data classes has made it probably impossible keep it as generic as it was before - I've went through a lot of trial an error on this one, but had to fall back on polymorphism in the end _(which tbf, it should have been using since the beginning based on what the code is doing)_.
