### PR TITLE
Change NewData from Asset type to String - As for now at least, we on…

### DIFF
--- a/AssetInformationApi/V1/Factories/AssetSnsFactory.cs
+++ b/AssetInformationApi/V1/Factories/AssetSnsFactory.cs
@@ -23,7 +23,7 @@ namespace AssetInformationApi.V1.Factories
                 SourceSystem = CreateAssetEventConstants.SOURCE_SYSTEM,
                 EventData = new EventData
                 {
-                    NewData = asset
+                    NewData = asset.AssetId
                 },
                 User = new User { Name = token.Name, Email = token.Email }
             };


### PR DESCRIPTION
RepairsListener, line 25, errors when it receives an object of type Asset

**RepairsListener** - message is of type **Asset**
![image](https://github.com/LBHackney-IT/asset-information-api/assets/70756861/72d9d673-a98b-4b8e-ac32-f4f4808ab1cc)

**Error**
![image](https://github.com/LBHackney-IT/asset-information-api/assets/70756861/2add5a49-6b4f-4022-a395-5406f551319d)

RepairsListener only needs the AssetID/PropRef to run the stored procedure to assign DLO contracts to the new asset. With this PR we're only sending a string, instead of an Asset. 

**Note and and potential alternative plan of action**
Not sure if this is the right approach, as it may be coupling the Listener with AssetAPI, suggestions welcome.

At the same time, if required in the future, we could introduce an assetApiGateway and retrieve the full asset as it happens in the [this file](https://github.dev/LBHackney-IT/housing-search-listener/blob/67b284a701e8b4daba5fdf0200c0d4c7ceaef4bb/HousingSearchListener/V1/UseCase/UpdateAssetUseCase.cs), in HousingSearchListener

### Alternative
Alternatively, looking at how the UpdatedAsset event works, it seems that this sends an object of type AssetDb, rather than Asset, so maybe doing the same could fix the "Unable to cast issue". 
![image](https://github.com/LBHackney-IT/asset-information-api/assets/70756861/6da648f0-07d8-4fe0-a4c4-2618388e3f7b)


Suggestions are welcome
