### PR TITLE
MR-516 - Added logging to see the asset object that is sent in the SNS message

### DIFF
--- a/AssetInformationApi/V1/UseCase/NewAssetUseCase.cs
+++ b/AssetInformationApi/V1/UseCase/NewAssetUseCase.cs
@@ -10,6 +10,7 @@ using System;
 using Hackney.Core.JWT;
 using Microsoft.Extensions.Logging;
 using AssetInformationApi.V1.Gateways.Interfaces;
+using Newtonsoft.Json;
 
 namespace AssetInformationApi.V1.UseCase
 {
@@ -36,6 +37,9 @@ namespace AssetInformationApi.V1.UseCase
             var asset = await _gateway.AddAsset(request).ConfigureAwait(false);
             if (asset != null && token != null)
             {
+                string jsonAsset = JsonConvert.SerializeObject(asset);
+                _logger.LogDebug("Publishing SNS message after creation of new asset with prop ref: {AssetId}. Asset body: {JsonAsset}", asset.AssetId, jsonAsset);
+
                 var assetSnsMessage = _snsFactory.CreateAsset(asset, token);
                 var assetTopicArn = Environment.GetEnvironmentVariable("ASSET_SNS_ARN");
                 await _snsGateway.Publish(assetSnsMessage, assetTopicArn).ConfigureAwait(false);


### PR DESCRIPTION
![image](https://github.com/LBHackney-IT/asset-information-api/assets/70756861/e707ccbd-0003-4f2c-acee-8138a5a2a728)

I would have expected to see the asset object within NewData, however the above screenshot (from RepairsListener logs) shows an unexpected value. This may be the reason why RepairsListener then fails to convert the value of NewData into an Asset.