### PR TITLE
MR-516 - Add getter and setter for AddDefaultSorContracts property in AddAssetRequest

### DIFF
--- a/AssetInformationApi/V1/Boundary/Request/AddAssetRequest.cs
+++ b/AssetInformationApi/V1/Boundary/Request/AddAssetRequest.cs
@@ -4,6 +4,6 @@ namespace AssetInformationApi.V1.Boundary.Request
 {
     public class AddAssetRequest : Asset
     {
-        public bool AddDefaultSorContracts = false;
+        public bool AddDefaultSorContracts { get; set; } = false;
     }
 }


### PR DESCRIPTION
FE sends request with AddDefaultSorContracts set to true, BE receives it and the AddDefaultSorContracts is not there at all in the body of the request in the log.

![image](https://github.com/LBHackney-IT/asset-information-api/assets/70756861/5a484bcb-a0ac-4164-b6f6-9317ae2566a9)

![image](https://github.com/LBHackney-IT/asset-information-api/assets/70756861/9ce95746-b710-4d99-b95c-d8d082540143)

Added getter and setter for AddDefaultSorContracts property in AddAssetRequest
