### PR TITLE
Update DynamoDB to OnDemand mode

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -1,8 +1,6 @@
 resource "aws_dynamodb_table" "assetinformationapi_dynamodb_table" {
   name           = "Assets"
-  billing_mode   = "PROVISIONED"
-  read_capacity  = 10
-  write_capacity = 10
+  billing_mode   = "PAY_PER_REQUEST"
   hash_key       = "id"
 
   attribute {

--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -1,8 +1,6 @@
 resource "aws_dynamodb_table" "assetinformationapi_dynamodb_table" {
   name           = "Assets"
-  billing_mode   = "PROVISIONED"
-  read_capacity  = 10
-  write_capacity = 10
+  billing_mode   = "PAY_PER_REQUEST"
   hash_key       = "id"
 
   attribute {

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -1,8 +1,6 @@
 resource "aws_dynamodb_table" "assetinformationapi_dynamodb_table" {
   name           = "Assets"
-  billing_mode   = "PROVISIONED"
-  read_capacity  = 10
-  write_capacity = 10
+  billing_mode   = "PAY_PER_REQUEST"
   hash_key       = "id"
 
   attribute {


### PR DESCRIPTION


`PAY_PER_REQUEST` is the value for on-demand mode.

[https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#billing_mode](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#billing_mode)