### PR TITLE
Remove RW values from GSI's

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -27,16 +27,12 @@ resource "aws_dynamodb_table" "assetinformationapi_dynamodb_table" {
     name            = "AssetParentsAndChilds"
     hash_key        = "rootAsset"
     range_key       = "parentAssetIds"
-    write_capacity  = 10
-    read_capacity   = 10
     projection_type = "ALL"
   }
 
   global_secondary_index {
     name            = "AssetId"
     hash_key        = "assetId"
-    write_capacity  = 10
-    read_capacity   = 10
     projection_type = "ALL"
   }
 

--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -27,16 +27,12 @@ resource "aws_dynamodb_table" "assetinformationapi_dynamodb_table" {
     name            = "AssetParentsAndChilds"
     hash_key        = "rootAsset"
     range_key       = "parentAssetIds"
-    write_capacity  = 10
-    read_capacity   = 10
     projection_type = "ALL"
   }
 
   global_secondary_index {
     name            = "AssetId"
     hash_key        = "assetId"
-    write_capacity  = 10
-    read_capacity   = 10
     projection_type = "ALL"
   }
 

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -27,16 +27,12 @@ resource "aws_dynamodb_table" "assetinformationapi_dynamodb_table" {
     name            = "AssetParentsAndChilds"
     hash_key        = "rootAsset"
     range_key       = "parentAssetIds"
-    write_capacity  = 10
-    read_capacity   = 10
     projection_type = "ALL"
   }
 
   global_secondary_index {
     name            = "AssetId"
     hash_key        = "assetId"
-    write_capacity  = 10
-    read_capacity   = 10
     projection_type = "ALL"
   }
 


### PR DESCRIPTION
Global Secondary Indexes will use On-Demand mode of the table does. This PR just removes the read/write values because they wont be used