### PR TITLE
Update Sonar Scanner & Cap Serverless.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Build lambda
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   aws-ecr: circleci/aws-ecr@3.0.0
   aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
-  sonarcloud: sonarsource/sonarcloud@1.1.1
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
   docker-python:

--- a/AssetInformationApi.Tests/Dockerfile
+++ b/AssetInformationApi.Tests/Dockerfile
@@ -14,7 +14,7 @@ ENV DynamoDb_LocalMode='true'
 WORKDIR /app
 
 # Install and run sonar cloud scanner
-RUN apt-get update && apt-get install -y openjdk-11-jdk
+RUN apt-get update && apt-get install -y openjdk-17-jdk
 RUN dotnet tool install --global dotnet-sonarscanner --version 5.6.0
 ENV PATH="$PATH:/root/.dotnet/tools"
 

--- a/AssetInformationApi.Tests/Dockerfile
+++ b/AssetInformationApi.Tests/Dockerfile
@@ -14,7 +14,7 @@ ENV DynamoDb_LocalMode='true'
 WORKDIR /app
 
 # Install and run sonar cloud scanner
-RUN apt-get update && apt-get install -y openjdk-17-jdk
+RUN apt-get update && apt-get install -y openjdk-17-jdk && apt-get clean
 RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 

--- a/AssetInformationApi.Tests/Dockerfile
+++ b/AssetInformationApi.Tests/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 
 # Install and run sonar cloud scanner
 RUN apt-get update && apt-get install -y openjdk-17-jdk
-RUN dotnet tool install --global dotnet-sonarscanner --version 5.6.0
+RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 
 RUN dotnet sonarscanner begin /k:"LBHackney-IT_asset-information-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"


### PR DESCRIPTION
# What:
 - Cap the serverless version to V3.
 - Update Java Sdk (&runtime) to V17
 - Change sonar scan orb to v2.
 - Remove the version limiter on docker sonar scanner.

# Why:
 - Because V4 introduces unfavourable licensing changes.
 - New Sonar Scanner version needs newer Java and orb.