### PR TITLE
TS-1698 Add support for TA block-unit relationships in AssetManagement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ tmp/
 .ionide
 
 testresults/
+
+#LocalStack
+.localstack

--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.40.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.42" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AssetInformationApi.Tests/V1/E2ETests/Fixtures/AssetsFixture.cs
+++ b/AssetInformationApi.Tests/V1/E2ETests/Fixtures/AssetsFixture.cs
@@ -1,14 +1,11 @@
-using Hackney.Core.Testing.DynamoDb;
-using AutoFixture;
-using System;
-using Hackney.Shared.Asset.Infrastructure;
-using Hackney.Shared.Asset.Domain;
 using Amazon.SimpleNotificationService;
-using System.Collections.Generic;
-using Amazon.DynamoDBv2.DataModel;
-using Hackney.Shared.Asset.Factories;
-using AssetInformationApi.V1.Boundary.Request;
+using AutoFixture;
+using Hackney.Core.Testing.DynamoDb;
 using Hackney.Shared.Asset.Boundary.Request;
+using Hackney.Shared.Asset.Domain;
+using Hackney.Shared.Asset.Factories;
+using Hackney.Shared.Asset.Infrastructure;
+using System;
 
 namespace AssetInformationApi.Tests.V1.E2ETests.Fixtures
 {
@@ -70,6 +67,8 @@ namespace AssetInformationApi.Tests.V1.E2ETests.Fixtures
             var asset = _fixture.Build<Asset>()
                 .With(x => x.VersionNumber, (int?) null)
                 .With(x => x.AssetId, "12345678910")
+                //stop AssetManagement validation from interfering since that property is not relevant to the test
+                .With(x => x.AssetManagement, (AssetManagement) null)
                 .Create();
             asset.Id = Guid.NewGuid();
 

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.40.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.42" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">

--- a/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
+++ b/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
@@ -14,6 +14,19 @@ namespace AssetInformationApi.V1.Boundary.Request.Validation
                                  .NotEmpty();
             RuleFor(x => x.AssetAddress.PostCode).NotNull()
                                  .NotEmpty();
+
+            When(x => x.AssetManagement != null, () =>
+            {
+                RuleFor(x => x.AssetManagement.IsTemporaryAccomodation)
+                    .Must(x => x == true)
+                    .When(x => x.AssetManagement.IsTemporaryAccommodationBlock == true)
+                    .WithMessage("IsTemporaryAccomodation must be true when IsTemporaryAccommodationBlock is set to true");
+
+                RuleFor(x => x.AssetManagement.TemporaryAccommodationParentAssetId)
+                    .Null()
+                    .When(x => x.AssetManagement.IsTemporaryAccommodationBlock == true)
+                    .WithMessage("Temporary accommodation block cannot have TemporaryAccommodationParentAssetId");
+            });
         }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1698](https://hackney.atlassian.net/browse/TS-1698)

## Describe this PR

### *What is the problem we're trying to solve*

This update implements the two new properties (`IsTemporaryAccommodationBlock` and `TemporaryAccommodationParentAssetId`) for TA to add support for block-unit relationships. Please see the [asset-shared package PR](https://github.com/LBHackney-IT/asset-shared/pull/47) for details and context.

### *What changes have we introduced*

1. Update the asset-shared package to 0.42
2. Add validation for the new properties 
3. Stop the new validation rules from interfering with existing test which does not target these properties
4. Add .localstack files to .gitignore

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-1698]: https://hackney.atlassian.net/browse/TS-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ