### PR TITLE
TS-1917 Allow ta assets without postcode

### DIFF
--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
 {
+#nullable enable
     public class AddAssetRequestValidatorTests
     {
         private readonly AddAssetRequestValidator _sut;
@@ -35,6 +36,34 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
             result.ShouldHaveValidationErrorFor(x => x.AssetAddress.AddressLine1);
             result.ShouldHaveValidationErrorFor(x => x.AssetAddress.PostCode);
         }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void RequestShouldNotErrorWhenPostcodeIsEmptyOrNullForTemporarysAccommodationAsset(string? postcode)
+        {
+            var assetmanagement = new Hackney.Shared.Asset.Domain.AssetManagement()
+            {
+                IsTemporaryAccomodation = true
+            };
+
+            var assetAddress = _fixture
+                .Build<Hackney.Shared.Asset.Domain.AssetAddress>()
+                .With(x => x.PostCode, postcode)
+                .Create();
+
+            var model = new AddAssetRequest()
+            {
+                Id = Guid.NewGuid(),
+                AssetAddress = assetAddress,
+                AssetManagement = assetmanagement
+            };
+
+            var result = _sut.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(x => x.AssetAddress.PostCode);
+        }
+
 
         #region AssetManagement
         [Theory]

--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
@@ -64,6 +64,28 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
             result.ShouldNotHaveValidationErrorFor(x => x.AssetAddress.PostCode);
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void RequestShouldErrorWhenPostCodeIsNullOrEmptyAndAssetManagementIsNull(string? postcode)
+        {
+            var assetAddress = _fixture
+                .Build<Hackney.Shared.Asset.Domain.AssetAddress>()
+                .With(x => x.PostCode, postcode)
+                .Create();
+
+            var model = new AddAssetRequest()
+            {
+                Id = Guid.NewGuid(),
+                AssetAddress = assetAddress,
+                AssetManagement = null
+            };
+
+            var result = _sut.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.PostCode);
+        }
+
 
         #region AssetManagement
         [Theory]

--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
@@ -86,7 +86,6 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
             result.ShouldHaveValidationErrorFor(x => x.AssetAddress.PostCode);
         }
 
-
         #region AssetManagement
         [Theory]
         [InlineData(null)]

--- a/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
+++ b/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
@@ -15,7 +15,7 @@ namespace AssetInformationApi.V1.Boundary.Request.Validation
             RuleFor(x => x.AssetAddress.PostCode)
                 .NotNull()
                 .NotEmpty()
-                .When(x => x.AssetManagement.IsTemporaryAccomodation != true);
+                .When(x => x.AssetManagement?.IsTemporaryAccomodation != true);
 
             When(x => x.AssetManagement != null, () =>
             {

--- a/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
+++ b/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
@@ -12,8 +12,10 @@ namespace AssetInformationApi.V1.Boundary.Request.Validation
             RuleFor(x => x.AssetAddress).NotNull();
             RuleFor(x => x.AssetAddress.AddressLine1).NotNull()
                                  .NotEmpty();
-            RuleFor(x => x.AssetAddress.PostCode).NotNull()
-                                 .NotEmpty();
+            RuleFor(x => x.AssetAddress.PostCode)
+                .NotNull()
+                .NotEmpty()
+                .When(x => x.AssetManagement.IsTemporaryAccomodation != true);
 
             When(x => x.AssetManagement != null, () =>
             {


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1917](https://hackney.atlassian.net/browse/TS-1917)

## Describe this PR

### *What is the problem we're trying to solve*

Currently `AddAssetRequestValidator` does not allow assets to be created without a postcode. In Temporray Accommodation we need to be able to create assets that don't have a postcode. These are typically block assets which have child UPRNs assiociated with them. There are also some other individual assets that don't have a postcode and we need to be able to add those as well in order for TA to function correctly. 

### *What changes have we introduced*
Update the `AddAssetRequestValidator` to allow assets without postcode when creating TA assets. It looks like there are no use cases for wider relaxation of this rule, so that's why it's limited to TA assets.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-1917]: https://hackney.atlassian.net/browse/TS-1917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ