### PR TITLE
TS-1921 Add support for IsPartOfTemporaryAccommodationBlock flag in AssetManagement

### DIFF
--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.42" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.43.0-feat-ts-1921-add0001" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.43.0-feat-ts-1921-add0001" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.44.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
@@ -141,6 +141,94 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
             result.ShouldHaveValidationErrorFor(x => x.AssetManagement.TemporaryAccommodationParentAssetId);
             result.Errors.Any(x => x.ErrorMessage == expectedErrorMessage).Should().BeTrue();
         }
+
+        [Fact]
+        public void RequestShouldErrorWhenIsPartOfTemporaryAccommodationBlockIsTrueAndTemporaryAccommodationParentAssetIdIsNull()
+        {
+            var assetmanagement = new Hackney.Shared.Asset.Domain.AssetManagement()
+            {
+                IsTemporaryAccomodation = true,
+                IsTemporaryAccommodationBlock = false,
+                IsPartOfTemporaryAccommodationBlock = true,
+                TemporaryAccommodationParentAssetId = null,
+            };
+
+            var assetAddress = _fixture.Create<Hackney.Shared.Asset.Domain.AssetAddress>();
+
+            var model = new AddAssetRequest()
+            {
+                Id = Guid.NewGuid(),
+                AssetAddress = assetAddress,
+                AssetManagement = assetmanagement,
+            };
+
+            var expectedErrorMessage = "TemporaryAccommodationParentAssetId cannot be null when IsPartOfTemporaryAccommodationBlock is true";
+
+            var result = _sut.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(x => x.AssetManagement.TemporaryAccommodationParentAssetId);
+            result.Errors.Any(x => x.ErrorMessage == expectedErrorMessage).Should().BeTrue();
+        }
+
+        [Fact]
+        public void RequestShouldErrorWhenIsPartOfTemporaryAccommodationBlockIsTrueAndIsTemporaryAccommodationBlockIsTrue()
+        {
+            var assetManagement = new Hackney.Shared.Asset.Domain.AssetManagement()
+            {
+                IsTemporaryAccomodation = true,
+                IsTemporaryAccommodationBlock = true,
+                IsPartOfTemporaryAccommodationBlock = true,
+                TemporaryAccommodationParentAssetId = null,
+            };
+
+            var assetAddress = _fixture.Create<Hackney.Shared.Asset.Domain.AssetAddress>();
+
+            var model = new AddAssetRequest()
+            {
+                Id = Guid.NewGuid(),
+                AssetAddress = assetAddress,
+                AssetManagement = assetManagement,
+            };
+
+            var expectedErrorMessage = "IsPartOfTemporaryAccommodationBlock cannot be true when IsTemporaryAccommodationBlock is true";
+
+            var result = _sut.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(x => x.AssetManagement.IsPartOfTemporaryAccommodationBlock);
+            result.Errors.Any(x => x.ErrorMessage == expectedErrorMessage).Should().BeTrue();
+        }
+
+        [Fact]
+        public void RequestShouldErrorWhenTASpecificPropertiesAreSetForNonTAAsset()
+        {
+            var assetManagement = new Hackney.Shared.Asset.Domain.AssetManagement()
+            {
+                IsTemporaryAccomodation = false,
+                IsTemporaryAccommodationBlock = true,
+                IsPartOfTemporaryAccommodationBlock = true,
+                TemporaryAccommodationParentAssetId = Guid.NewGuid(),
+            };
+
+            var assetAddress = _fixture.Create<Hackney.Shared.Asset.Domain.AssetAddress>();
+
+            var model = new AddAssetRequest()
+            {
+                Id = Guid.NewGuid(),
+                AssetAddress = assetAddress,
+                AssetManagement = assetManagement,
+            };
+
+            var expectedErrorMessageForIsTemporaryAccommodationBlock = "IsTemporaryAccommodationBlock cannot be true when IsTemporaryAccomodation is false";
+            var expectedErrorMessageForIsPartOfTemporaryAccommodationBlock = "IsPartOfTemporaryAccommodationBlock cannot be true when IsTemporaryAccomodation is false";
+            var expectedErrorMessageForTemporaryAccommodationParentAssetId = "TemporaryAccommodationParentAssetId must be null when IsTemporaryAccomodation is false";
+
+            var result = _sut.TestValidate(model);
+
+            result.ShouldHaveValidationErrorFor(x => x.AssetManagement.IsTemporaryAccommodationBlock);
+            result.Errors.Any(x => x.ErrorMessage == expectedErrorMessageForIsTemporaryAccommodationBlock).Should().BeTrue();
+            result.Errors.Any(x => x.ErrorMessage == expectedErrorMessageForIsPartOfTemporaryAccommodationBlock).Should().BeTrue();
+            result.Errors.Any(x => x.ErrorMessage == expectedErrorMessageForTemporaryAccommodationParentAssetId).Should().BeTrue();
+        }
         #endregion
     }
 }

--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
@@ -199,11 +199,38 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
         }
 
         [Fact]
-        public void RequestShouldErrorWhenTASpecificPropertiesAreSetForNonTAAsset()
+        public void RequestShouldNotHaveErrorsWhenIsTemporaryAccommodationBlockIsTrueAndIsPartOfTemporaryAccommodationBlockIsNull()
+        {
+
+            var assetManagement = new Hackney.Shared.Asset.Domain.AssetManagement()
+            {
+                IsTemporaryAccomodation = true,
+                IsTemporaryAccommodationBlock = true,
+                TemporaryAccommodationParentAssetId = null,
+            };
+
+            var assetAddress = _fixture.Create<Hackney.Shared.Asset.Domain.AssetAddress>();
+
+            var model = new AddAssetRequest()
+            {
+                Id = Guid.NewGuid(),
+                AssetAddress = assetAddress,
+                AssetManagement = assetManagement,
+            };
+
+            var result = _sut.TestValidate(model);
+
+            result.ShouldNotHaveValidationErrorFor(x => x.AssetManagement.IsPartOfTemporaryAccommodationBlock);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(null)]
+        public void RequestShouldErrorWhenTASpecificPropertiesAreSetForNonTAAsset(bool? isTemporaryAccommodation)
         {
             var assetManagement = new Hackney.Shared.Asset.Domain.AssetManagement()
             {
-                IsTemporaryAccomodation = false,
+                IsTemporaryAccomodation = isTemporaryAccommodation,
                 IsTemporaryAccommodationBlock = true,
                 IsPartOfTemporaryAccommodationBlock = true,
                 TemporaryAccommodationParentAssetId = Guid.NewGuid(),

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.42" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.43.0-feat-ts-1921-add0001" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.43.0-feat-ts-1921-add0001" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.44.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">

--- a/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
+++ b/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
@@ -28,7 +28,34 @@ namespace AssetInformationApi.V1.Boundary.Request.Validation
                     .Null()
                     .When(x => x.AssetManagement.IsTemporaryAccommodationBlock == true)
                     .WithMessage("Temporary accommodation block cannot have TemporaryAccommodationParentAssetId");
+
+                RuleFor(x => x.AssetManagement.TemporaryAccommodationParentAssetId)
+                    .NotNull()
+                    .When(x => x.AssetManagement.IsPartOfTemporaryAccommodationBlock == true)
+                    .WithMessage("TemporaryAccommodationParentAssetId cannot be null when IsPartOfTemporaryAccommodationBlock is true");
+
+                RuleFor(x => x.AssetManagement.IsPartOfTemporaryAccommodationBlock)
+                    .Must(x => x == false)
+                    .When(x => x.AssetManagement.IsTemporaryAccommodationBlock == true)
+                    .WithMessage("IsPartOfTemporaryAccommodationBlock cannot be true when IsTemporaryAccommodationBlock is true");
+
+                When(x => x.AssetManagement.IsTemporaryAccomodation == false, () =>
+                {
+                    RuleFor(x => x.AssetManagement.IsTemporaryAccommodationBlock)
+                        .Must(x => x == false)
+                        .WithMessage("IsTemporaryAccommodationBlock cannot be true when IsTemporaryAccomodation is false");
+
+                    RuleFor(x => x.AssetManagement.IsPartOfTemporaryAccommodationBlock)
+                        .Must(x => x == false)
+                        .WithMessage("IsPartOfTemporaryAccommodationBlock cannot be true when IsTemporaryAccomodation is false");
+
+                    RuleFor(x => x.AssetManagement.TemporaryAccommodationParentAssetId)
+                        .Null()
+                        .WithMessage("TemporaryAccommodationParentAssetId must be null when IsTemporaryAccomodation is false");
+                });
             });
+
+
         }
     }
 }

--- a/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
+++ b/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
@@ -35,11 +35,11 @@ namespace AssetInformationApi.V1.Boundary.Request.Validation
                     .WithMessage("TemporaryAccommodationParentAssetId cannot be null when IsPartOfTemporaryAccommodationBlock is true");
 
                 RuleFor(x => x.AssetManagement.IsPartOfTemporaryAccommodationBlock)
-                    .Must(x => x == false)
+                    .Must(x => x == false || x == null)
                     .When(x => x.AssetManagement.IsTemporaryAccommodationBlock == true)
                     .WithMessage("IsPartOfTemporaryAccommodationBlock cannot be true when IsTemporaryAccommodationBlock is true");
 
-                When(x => x.AssetManagement.IsTemporaryAccomodation == false, () =>
+                When(x => x.AssetManagement.IsTemporaryAccomodation == false || x.AssetManagement.IsTemporaryAccomodation == null, () =>
                 {
                     RuleFor(x => x.AssetManagement.IsTemporaryAccommodationBlock)
                         .Must(x => x == false)


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1921](https://hackney.atlassian.net/browse/TS-1921)

## Describe this PR

### *What is the problem we're trying to solve*

Please see the context in this [PR](https://github.com/LBHackney-IT/asset-shared/pull/49) for the updated asset shared package.

### *What changes have we introduced*

1. Add support for new `IsPartOfTemporaryAccommodationBlock` property in `AssetManagement`
2. Update the `AddAssetRequestValidator` with business rules that apply to the `IsPartOfTemporaryAccommodationBlock` property
3. Update the `Hackney.Shared.Asset` package to version `0.44.0` which adds the new property

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-1921]: https://hackney.atlassian.net/browse/TS-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ