### PR TITLE
TS-2146 Remove postcode validation

### DIFF
--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
@@ -29,34 +29,11 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
         }
 
         [Fact]
-        public void RequestShouldErrorForEmptyAddress()
+        public void RequestShouldErrorForEmptyAddressLine1()
         {
             var model = new AddAssetRequest() { Id = Guid.NewGuid(), AssetAddress = new Hackney.Shared.Asset.Domain.AssetAddress() };
             var result = _sut.TestValidate(model);
             result.ShouldHaveValidationErrorFor(x => x.AssetAddress.AddressLine1);
-            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.PostCode);
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
-        public void RequestShouldErrorWhenPostCodeIsNullOrEmptyAndAssetManagementIsNull(string? postcode)
-        {
-            var assetAddress = _fixture
-                .Build<Hackney.Shared.Asset.Domain.AssetAddress>()
-                .With(x => x.PostCode, postcode)
-                .Create();
-
-            var model = new AddAssetRequest()
-            {
-                Id = Guid.NewGuid(),
-                AssetAddress = assetAddress,
-                AssetManagement = null
-            };
-
-            var result = _sut.TestValidate(model);
-
-            result.ShouldHaveValidationErrorFor(x => x.AssetAddress.PostCode);
         }
 
         #region AssetManagement

--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
@@ -40,33 +40,6 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void RequestShouldNotErrorWhenPostcodeIsEmptyOrNullForTemporarysAccommodationAsset(string? postcode)
-        {
-            var assetmanagement = new Hackney.Shared.Asset.Domain.AssetManagement()
-            {
-                IsTemporaryAccomodation = true
-            };
-
-            var assetAddress = _fixture
-                .Build<Hackney.Shared.Asset.Domain.AssetAddress>()
-                .With(x => x.PostCode, postcode)
-                .Create();
-
-            var model = new AddAssetRequest()
-            {
-                Id = Guid.NewGuid(),
-                AssetAddress = assetAddress,
-                AssetManagement = assetmanagement
-            };
-
-            var result = _sut.TestValidate(model);
-
-            result.ShouldNotHaveValidationErrorFor(x => x.AssetAddress.PostCode);
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
         public void RequestShouldErrorWhenPostCodeIsNullOrEmptyAndAssetManagementIsNull(string? postcode)
         {
             var assetAddress = _fixture

--- a/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
+++ b/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
@@ -12,10 +12,6 @@ namespace AssetInformationApi.V1.Boundary.Request.Validation
             RuleFor(x => x.AssetAddress).NotNull();
             RuleFor(x => x.AssetAddress.AddressLine1).NotNull()
                                  .NotEmpty();
-            RuleFor(x => x.AssetAddress.PostCode)
-                .NotNull()
-                .NotEmpty()
-                .When(x => x.AssetManagement?.IsTemporaryAccomodation != true);
 
             When(x => x.AssetManagement != null, () =>
             {


### PR DESCRIPTION
## Link to JIRA ticket

[TS-2146](https://hackney.atlassian.net/browse/TS-2146)

## Describe this PR

### *What is the problem we're trying to solve*

A while back we relaxed the post code validation rules, so that it's not required for TA assets. Now that we are further down the property hierarchy feature it has become obvious that we need to be able to create not just TA, but any assets without the post code.

The main reason is the flow where we add a standalone asset that belongs to a block, but we don't want to add the block as TA asset yet, but need it just for creating the UPRN based parent-child asset relationship.

For example this block doesn't have a postcode: 
![image](https://github.com/user-attachments/assets/5c3c5836-39d5-49bb-b497-52ff09abf172)

In scenario where the block doesn't already exist in TA and we want to add any of the units as standalone assets the API call for creating the block as a parent asset fails because it doesn't have a postcode. It is is important that we don't have to flag the block in this scenario as TA asset because that's how we track what assets are actually being used for TA purposes. By flagging it as TA here we wouldn't be able to add it as a TA block later which is one of the key features required for the TA asset management to work.

If we wanted to add that sample block as a TA block and include some of the units in it we would flag the block to be TA asset as well, so the validation wouldn't affect that flow.

All those TA specific flows aside the fact that we have properties that don't have postcode kind of makes the mandatory postcode requirement reduntant, so it should be safe to remove it altogether. 

### *What changes have we introduced*

1. Update the validation rules to allow missing postcode for all asset types
2. Update the tests to reflect the new rules. Some tests have been removed altogether since they are no longer relevant

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-2146]: https://hackney.atlassian.net/browse/TS-2146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ