### PR TITLE
TS-2146 allow postcode validation bypass

### DIFF
--- a/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
+++ b/AssetInformationApi.Tests/V1/Boundary/Request/Validation/AddAssetRequestValidatorTests.cs
@@ -40,13 +40,8 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void RequestShouldNotErrorWhenPostcodeIsEmptyOrNullForTemporarysAccommodationAsset(string? postcode)
+        public void RequestShouldNotErrorWhenPostcodeIsEmptyOrNullWhenBypassPostcodeValidationIsTrue(string? postcode)
         {
-            var assetmanagement = new Hackney.Shared.Asset.Domain.AssetManagement()
-            {
-                IsTemporaryAccomodation = true
-            };
-
             var assetAddress = _fixture
                 .Build<Hackney.Shared.Asset.Domain.AssetAddress>()
                 .With(x => x.PostCode, postcode)
@@ -56,7 +51,7 @@ namespace AssetInformationApi.Tests.V1.Boundary.Request.Validation
             {
                 Id = Guid.NewGuid(),
                 AssetAddress = assetAddress,
-                AssetManagement = assetmanagement
+                BypassPostcodeValidation = true
             };
 
             var result = _sut.TestValidate(model);

--- a/AssetInformationApi/V1/Boundary/Request/AddAssetRequest.cs
+++ b/AssetInformationApi/V1/Boundary/Request/AddAssetRequest.cs
@@ -5,5 +5,6 @@ namespace AssetInformationApi.V1.Boundary.Request
     public class AddAssetRequest : Asset
     {
         public bool AddDefaultSorContracts { get; set; } = false;
+        public bool BypassPostcodeValidation { get; set; } = false;
     }
 }

--- a/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
+++ b/AssetInformationApi/V1/Boundary/Request/Validation/AddAssetRequestValidator.cs
@@ -15,7 +15,7 @@ namespace AssetInformationApi.V1.Boundary.Request.Validation
             RuleFor(x => x.AssetAddress.PostCode)
                 .NotNull()
                 .NotEmpty()
-                .When(x => x.AssetManagement?.IsTemporaryAccomodation != true);
+                .When(x => x.BypassPostcodeValidation == false);
 
             When(x => x.AssetManagement != null, () =>
             {


### PR DESCRIPTION
## Link to JIRA ticket

[TS-2146](https://hackney.atlassian.net/browse/TS-2146)

## Describe this PR

### *What is the problem we're trying to solve*

Please see this [closed PR](https://github.com/LBHackney-IT/asset-information-api/pull/171) for context and discussions on how we ended up with this implementation.

### *What changes have we introduced*

1. Add new `BypassPostcodeValidation ` property to `AddAssetRequest` object. This is set to false by default.
2. Update `AddAssetRequestValidator` to ignore postcode validation when `BypassPostcodeValidation` is set to true
3. Remove the previous rule where postcode validation was ignored for all TA assets. TA clients must now bypass the validation in cases where postcode is not available

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-2146]: https://hackney.atlassian.net/browse/TS-2146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ