### PR TITLE
Upgrade asset shared package version

### DIFF
--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.45.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.47.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.45.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.47.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">


### PR DESCRIPTION
[HPT-477](https://hackney.atlassian.net/browse/HPT-477) Flag to prevent repairs being booked tor Hackney new properties

Corresponds with this PR from asset shared:

https://github.com/LBHackney-IT/asset-shared/pull/52

Upgrade the asset API to include the package with the `IsUnderWarranty` flag field for HPT-477

[HPT-477]: https://hackney.atlassian.net/browse/HPT-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ