### PR TITLE
Update just the JWT core package to get the latest Token Factory.

### DIFF
--- a/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
+++ b/AssetInformationApi.Tests/AssetInformationApi.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.79.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0-feat-add-cognito0016" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />

--- a/AssetInformationApi/AssetInformationApi.csproj
+++ b/AssetInformationApi/AssetInformationApi.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.79.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0-feat-add-cognito0016" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package 2 versions up _(1.72 -> 1.84 -> 1.87)_.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.
 - The current v1.72 implementation crashes upon encountering Cognito Token due to empty `groups` key failing to map and leading `Token.Groups` to getting set as unhandled `null`.

# Notes:
 - This is just a preview version update.
 - Updating only the `JWT` core package without the `Authorizer` as after additional digging through source code I've found that `Authorizer` core package merely references the `JWT` core package's `ITokenFactory` interface definition, and does not do anything more with the package. The way the Google groups authentication setup works is that for any given API, it uses `JWT` core package to register `TokenFactory` instance DI, and then that gets used by the Authorizer middleware to populate its Auth filter dependencies. The rest of the `JWT` usage seems to be limited down to `Token` class to extract data like email or user name for Activity History purposes.
 - The version `1.84` was a fake release, accidentally triggered by some house cleaning done by the cyber team.
 - What changes does latest JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.